### PR TITLE
On production use the JSONRenderer only to avoid setting up static file serving

### DIFF
--- a/bioacoustics/config/production.py
+++ b/bioacoustics/config/production.py
@@ -9,3 +9,6 @@ class Production(Common):
     # https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts
     ALLOWED_HOSTS = ["*"]
     INSTALLED_APPS += ("gunicorn", )
+
+    REST_FRAMEWORK = Common.REST_FRAMEWORK
+    REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = ('rest_framework.renderers.JSONRenderer',)


### PR DESCRIPTION
Alternatively, we can set up a nginx sidecar to do the static file serving on production.