### PR TITLE
Add image_url to the milvus seach results

### DIFF
--- a/bioacoustics/milvus/views.py
+++ b/bioacoustics/milvus/views.py
@@ -23,7 +23,11 @@ class EntitySerializer(serializers.Serializer):
     def get_image_url(self, obj):
         return urljoin(
             settings.A2O_API_URL,
-            'audio_recordings/{}/media.png?end_offset=30&start_offset=0'.format(obj.file_seq_id)
+            'audio_recordings/{}/media.png?start_offset={}&end_offset={}'.format(
+                obj.file_seq_id,
+                obj.offset,
+                obj.offset + 5
+            )
         )
 
 


### PR DESCRIPTION
Example:

```
{
  "id": 31530,
  "distance": 6.256008148193359,
  "entity": {
      "site_id": 110,
      "site_name": "Eungella",
      "subsite_name": "Dry-A",
      "filename": "site_0110/20210507T140000+1000_Eungella-Dry-A_498000.flac",
      "file_seq_id": "498000",
      "file_timestamp": 1620360000,
      "offset": 1005,
      "image_url": "https://api.acousticobservatory.org/audio_recordings/498000/media.png?end_offset=30&start_offset=0"
  }
},
```