### PR TITLE
Adjust offset and limit values on search endpoint

### DIFF
--- a/bioacoustics/milvus/views.py
+++ b/bioacoustics/milvus/views.py
@@ -54,13 +54,11 @@ class SearchSerializer(serializers.Serializer):
     audio_file = serializers.FileField()
     limit = serializers.IntegerField(
         min_value=1,
-        max_value=5000,
+        max_value=17000,
         required=False,
         allow_null=True
     )
     offset = serializers.IntegerField(
-        min_value=0,
-        max_value=5000,
         required=False,
         allow_null=True
     )


### PR DESCRIPTION
- Remove max and min values for `offset`
- Increase max value of  `limit` to 17000